### PR TITLE
Use the applicationContext to load the SofaRuntimeProperties to avoid premature initialization

### DIFF
--- a/isle-sofa-boot-starter/src/test/java/com/alipay/sofa/isle/ServiceAnnotationBeanPostProcessorTest.java
+++ b/isle-sofa-boot-starter/src/test/java/com/alipay/sofa/isle/ServiceAnnotationBeanPostProcessorTest.java
@@ -21,6 +21,7 @@ import com.alipay.sofa.runtime.api.annotation.SofaReferenceBinding;
 import com.alipay.sofa.runtime.api.annotation.SofaService;
 import com.alipay.sofa.runtime.api.annotation.SofaServiceBinding;
 import com.alipay.sofa.runtime.api.binding.BindingType;
+import com.alipay.sofa.runtime.constants.SofaRuntimeFrameworkConstants;
 import com.alipay.sofa.runtime.model.InterfaceMode;
 import com.alipay.sofa.runtime.service.component.Service;
 import com.alipay.sofa.runtime.service.component.impl.ReferenceImpl;
@@ -73,8 +74,13 @@ public class ServiceAnnotationBeanPostProcessorTest {
             ServiceAnnotationBeanPostProcessorTest.class.getClassLoader());
 
         ApplicationContext applicationContext = mock(ApplicationContext.class);
-        when(applicationContext.getBean(SofaRuntimeContext.class)).thenReturn(sofaRuntimeContext);
-        when(applicationContext.getBean(SofaRuntimeProperties.class)).thenReturn(null);
+        when(
+            applicationContext.getBean(SofaRuntimeFrameworkConstants.SOFA_RUNTIME_CONTEXT_BEAN_ID,
+                SofaRuntimeContext.class)).thenReturn(sofaRuntimeContext);
+        when(
+            applicationContext.getBean(
+                SofaRuntimeFrameworkConstants.SOFA_RUNTIME_PROPERTIES_BEAN_ID,
+                SofaRuntimeProperties.class)).thenReturn(null);
 
         boolean hasException = false;
         BindingConverterFactory bindingConverterFactory = new BindingConverterFactoryImpl();
@@ -133,8 +139,13 @@ public class ServiceAnnotationBeanPostProcessorTest {
             ServiceAnnotationBeanPostProcessorTest.class.getClassLoader());
 
         ApplicationContext applicationContext = mock(ApplicationContext.class);
-        when(applicationContext.getBean(SofaRuntimeContext.class)).thenReturn(sofaRuntimeContext);
-        when(applicationContext.getBean(SofaRuntimeProperties.class)).thenReturn(null);
+        when(
+            applicationContext.getBean(SofaRuntimeFrameworkConstants.SOFA_RUNTIME_CONTEXT_BEAN_ID,
+                SofaRuntimeContext.class)).thenReturn(sofaRuntimeContext);
+        when(
+            applicationContext.getBean(
+                SofaRuntimeFrameworkConstants.SOFA_RUNTIME_PROPERTIES_BEAN_ID,
+                SofaRuntimeProperties.class)).thenReturn(null);
 
         boolean hasException = false;
         BindingConverterFactory bindingConverterFactory = new BindingConverterFactoryImpl();

--- a/isle-sofa-boot-starter/src/test/java/com/alipay/sofa/isle/ServiceAnnotationBeanPostProcessorTest.java
+++ b/isle-sofa-boot-starter/src/test/java/com/alipay/sofa/isle/ServiceAnnotationBeanPostProcessorTest.java
@@ -30,6 +30,7 @@ import com.alipay.sofa.runtime.spi.component.SofaRuntimeContext;
 import com.alipay.sofa.runtime.spi.service.BindingConverter;
 import com.alipay.sofa.runtime.spi.service.BindingConverterFactory;
 import com.alipay.sofa.runtime.spring.ServiceAnnotationBeanPostProcessor;
+import com.alipay.sofa.runtime.spring.config.SofaRuntimeProperties;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -71,10 +72,15 @@ public class ServiceAnnotationBeanPostProcessorTest {
         when(sofaRuntimeContext.getAppClassLoader()).thenReturn(
             ServiceAnnotationBeanPostProcessorTest.class.getClassLoader());
 
+        ApplicationContext applicationContext = mock(ApplicationContext.class);
+        when(applicationContext.getBean(SofaRuntimeContext.class)).thenReturn(sofaRuntimeContext);
+        when(applicationContext.getBean(SofaRuntimeProperties.class)).thenReturn(null);
+
         boolean hasException = false;
         BindingConverterFactory bindingConverterFactory = new BindingConverterFactoryImpl();
         ServiceAnnotationBeanPostProcessor serviceAnnotationBeanPostProcessor = new ServiceAnnotationBeanPostProcessor(
-            sofaRuntimeContext, null, null, bindingConverterFactory);
+            null, bindingConverterFactory);
+        serviceAnnotationBeanPostProcessor.setApplicationContext(applicationContext);
         try {
             createReferenceProxy.invoke(serviceAnnotationBeanPostProcessor, sofaReference,
                 ServiceAnnotationBeanPostProcessorTest.class);
@@ -100,9 +106,6 @@ public class ServiceAnnotationBeanPostProcessorTest {
             .whenNew(ReferenceImpl.class)
             .withArguments("uniqueId", ServiceAnnotationBeanPostProcessorTest.class,
                 InterfaceMode.annotation, true).thenReturn(referenceImpl);
-        // mock an applicationContext
-        ApplicationContext applicationContext = mock(ApplicationContext.class);
-        serviceAnnotationBeanPostProcessor.setApplicationContext(applicationContext);
         createReferenceProxy.invoke(serviceAnnotationBeanPostProcessor, sofaReference,
             ServiceAnnotationBeanPostProcessorTest.class);
 
@@ -129,10 +132,15 @@ public class ServiceAnnotationBeanPostProcessorTest {
         when(sofaRuntimeContext.getAppClassLoader()).thenReturn(
             ServiceAnnotationBeanPostProcessorTest.class.getClassLoader());
 
+        ApplicationContext applicationContext = mock(ApplicationContext.class);
+        when(applicationContext.getBean(SofaRuntimeContext.class)).thenReturn(sofaRuntimeContext);
+        when(applicationContext.getBean(SofaRuntimeProperties.class)).thenReturn(null);
+
         boolean hasException = false;
         BindingConverterFactory bindingConverterFactory = new BindingConverterFactoryImpl();
         ServiceAnnotationBeanPostProcessor serviceAnnotationBeanPostProcessor = new ServiceAnnotationBeanPostProcessor(
-            sofaRuntimeContext, null, null, bindingConverterFactory);
+            null, bindingConverterFactory);
+        serviceAnnotationBeanPostProcessor.setApplicationContext(applicationContext);
         try {
             createReferenceProxy.invoke(serviceAnnotationBeanPostProcessor, service, sofaService,
                 sofaServiceBinding);

--- a/isle-sofa-boot-starter/src/test/java/com/alipay/sofa/isle/ServiceAnnotationBeanPostProcessorTest.java
+++ b/isle-sofa-boot-starter/src/test/java/com/alipay/sofa/isle/ServiceAnnotationBeanPostProcessorTest.java
@@ -36,6 +36,7 @@ import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.springframework.context.ApplicationContext;
 
 import java.lang.reflect.Method;
 import java.util.HashSet;
@@ -99,6 +100,9 @@ public class ServiceAnnotationBeanPostProcessorTest {
             .whenNew(ReferenceImpl.class)
             .withArguments("uniqueId", ServiceAnnotationBeanPostProcessorTest.class,
                 InterfaceMode.annotation, true).thenReturn(referenceImpl);
+        // mock an applicationContext
+        ApplicationContext applicationContext = mock(ApplicationContext.class);
+        serviceAnnotationBeanPostProcessor.setApplicationContext(applicationContext);
         createReferenceProxy.invoke(serviceAnnotationBeanPostProcessor, sofaReference,
             ServiceAnnotationBeanPostProcessorTest.class);
 

--- a/runtime-sofa-boot-starter/src/main/java/com/alipay/sofa/runtime/spring/ServiceAnnotationBeanPostProcessor.java
+++ b/runtime-sofa-boot-starter/src/main/java/com/alipay/sofa/runtime/spring/ServiceAnnotationBeanPostProcessor.java
@@ -21,6 +21,7 @@ import com.alipay.sofa.runtime.api.annotation.SofaReference;
 import com.alipay.sofa.runtime.api.annotation.SofaService;
 import com.alipay.sofa.runtime.api.annotation.SofaServiceBinding;
 import com.alipay.sofa.runtime.api.binding.BindingType;
+import com.alipay.sofa.runtime.constants.SofaRuntimeFrameworkConstants;
 import com.alipay.sofa.runtime.model.InterfaceMode;
 import com.alipay.sofa.runtime.service.binding.JvmBinding;
 import com.alipay.sofa.runtime.service.component.Reference;
@@ -241,14 +242,18 @@ public class ServiceAnnotationBeanPostProcessor implements BeanPostProcessor, Pr
 
     private SofaRuntimeProperties getSofaRuntimeProperties() {
         if (sofaRuntimeProperties == null) {
-            sofaRuntimeProperties = applicationContext.getBean(SofaRuntimeProperties.class);
+            sofaRuntimeProperties = applicationContext.getBean(
+                SofaRuntimeFrameworkConstants.SOFA_RUNTIME_PROPERTIES_BEAN_ID,
+                SofaRuntimeProperties.class);
         }
         return sofaRuntimeProperties;
     }
 
     private SofaRuntimeContext getSofaRuntimeContext() {
         if (sofaRuntimeContext == null) {
-            sofaRuntimeContext = applicationContext.getBean(SofaRuntimeContext.class);
+            sofaRuntimeContext = applicationContext.getBean(
+                SofaRuntimeFrameworkConstants.SOFA_RUNTIME_CONTEXT_BEAN_ID,
+                SofaRuntimeContext.class);
         }
         return sofaRuntimeContext;
     }

--- a/runtime-sofa-boot-starter/src/main/java/com/alipay/sofa/runtime/spring/ServiceAnnotationBeanPostProcessor.java
+++ b/runtime-sofa-boot-starter/src/main/java/com/alipay/sofa/runtime/spring/ServiceAnnotationBeanPostProcessor.java
@@ -64,6 +64,25 @@ public class ServiceAnnotationBeanPostProcessor implements BeanPostProcessor, Pr
     private BindingConverterFactory bindingConverterFactory;
     private ApplicationContext      applicationContext;
 
+    /**
+     * To construct a ServiceAnnotationBeanPostProcessor via a Spring Bean
+     * sofaRuntimeContext and sofaRuntimeProperties will be obtained from applicationContext
+     * @param bindingAdapterFactory
+     * @param bindingConverterFactory
+     */
+    public ServiceAnnotationBeanPostProcessor(BindingAdapterFactory bindingAdapterFactory,
+                                              BindingConverterFactory bindingConverterFactory) {
+        this.bindingAdapterFactory = bindingAdapterFactory;
+        this.bindingConverterFactory = bindingConverterFactory;
+    }
+
+    /**
+     * To manually construct a ServiceAnnotationBeanPostProcessor
+     * @param sofaRuntimeContext
+     * @param sofaRuntimeProperties
+     * @param bindingAdapterFactory
+     * @param bindingConverterFactory
+     */
     public ServiceAnnotationBeanPostProcessor(SofaRuntimeContext sofaRuntimeContext,
                                               SofaRuntimeProperties sofaRuntimeProperties,
                                               BindingAdapterFactory bindingAdapterFactory,
@@ -120,8 +139,8 @@ public class ServiceAnnotationBeanPostProcessor implements BeanPostProcessor, Pr
         }
 
         ComponentInfo componentInfo = new ServiceComponent(implementation, service,
-            bindingAdapterFactory, sofaRuntimeContext);
-        sofaRuntimeContext.getComponentManager().register(componentInfo);
+            bindingAdapterFactory, getSofaRuntimeContext());
+        getSofaRuntimeContext().getComponentManager().register(componentInfo);
     }
 
     private void processSofaReference(final Object bean) {
@@ -199,8 +218,8 @@ public class ServiceAnnotationBeanPostProcessor implements BeanPostProcessor, Pr
             BindingConverterContext bindingConverterContext = new BindingConverterContext();
             bindingConverterContext.setInBinding(false);
             bindingConverterContext.setApplicationContext(applicationContext);
-            bindingConverterContext.setAppName(sofaRuntimeContext.getAppName());
-            bindingConverterContext.setAppClassLoader(sofaRuntimeContext.getAppClassLoader());
+            bindingConverterContext.setAppName(getSofaRuntimeContext().getAppName());
+            bindingConverterContext.setAppClassLoader(getSofaRuntimeContext().getAppClassLoader());
             Binding binding = bindingConverter.convert(sofaServiceAnnotation, sofaServiceBinding,
                 bindingConverterContext);
             service.addBinding(binding);
@@ -227,14 +246,28 @@ public class ServiceAnnotationBeanPostProcessor implements BeanPostProcessor, Pr
             BindingConverterContext bindingConverterContext = new BindingConverterContext();
             bindingConverterContext.setInBinding(true);
             bindingConverterContext.setApplicationContext(applicationContext);
-            bindingConverterContext.setAppName(sofaRuntimeContext.getAppName());
-            bindingConverterContext.setAppClassLoader(sofaRuntimeContext.getAppClassLoader());
+            bindingConverterContext.setAppName(getSofaRuntimeContext().getAppName());
+            bindingConverterContext.setAppClassLoader(getSofaRuntimeContext().getAppClassLoader());
             Binding binding = bindingConverter.convert(sofaReferenceAnnotation,
                 sofaReferenceAnnotation.binding(), bindingConverterContext);
             reference.addBinding(binding);
         }
         return ReferenceRegisterHelper.registerReference(reference, bindingAdapterFactory,
-            sofaRuntimeProperties, sofaRuntimeContext);
+            getSofaRuntimeProperties(), getSofaRuntimeContext());
+    }
+
+    private SofaRuntimeProperties getSofaRuntimeProperties() {
+        if (sofaRuntimeProperties == null) {
+            sofaRuntimeProperties = applicationContext.getBean(SofaRuntimeProperties.class);
+        }
+        return sofaRuntimeProperties;
+    }
+
+    private SofaRuntimeContext getSofaRuntimeContext() {
+        if (sofaRuntimeContext == null) {
+            sofaRuntimeContext = applicationContext.getBean(SofaRuntimeContext.class);
+        }
+        return sofaRuntimeContext;
     }
 
     @Override

--- a/runtime-sofa-boot-starter/src/main/java/com/alipay/sofa/runtime/spring/ServiceAnnotationBeanPostProcessor.java
+++ b/runtime-sofa-boot-starter/src/main/java/com/alipay/sofa/runtime/spring/ServiceAnnotationBeanPostProcessor.java
@@ -76,23 +76,6 @@ public class ServiceAnnotationBeanPostProcessor implements BeanPostProcessor, Pr
         this.bindingConverterFactory = bindingConverterFactory;
     }
 
-    /**
-     * To manually construct a ServiceAnnotationBeanPostProcessor
-     * @param sofaRuntimeContext
-     * @param sofaRuntimeProperties
-     * @param bindingAdapterFactory
-     * @param bindingConverterFactory
-     */
-    public ServiceAnnotationBeanPostProcessor(SofaRuntimeContext sofaRuntimeContext,
-                                              SofaRuntimeProperties sofaRuntimeProperties,
-                                              BindingAdapterFactory bindingAdapterFactory,
-                                              BindingConverterFactory bindingConverterFactory) {
-        this.sofaRuntimeContext = sofaRuntimeContext;
-        this.sofaRuntimeProperties = sofaRuntimeProperties;
-        this.bindingAdapterFactory = bindingAdapterFactory;
-        this.bindingConverterFactory = bindingConverterFactory;
-    }
-
     @Override
     public Object postProcessBeforeInitialization(Object bean, String beanName)
                                                                                throws BeansException {

--- a/runtime-sofa-boot-starter/src/main/java/com/alipay/sofa/runtime/spring/configuration/SofaRuntimeAutoConfiguration.java
+++ b/runtime-sofa-boot-starter/src/main/java/com/alipay/sofa/runtime/spring/configuration/SofaRuntimeAutoConfiguration.java
@@ -98,12 +98,10 @@ public class SofaRuntimeAutoConfiguration {
     }
 
     @Bean
-    public ServiceAnnotationBeanPostProcessor serviceAnnotationBeanPostProcessor(SofaRuntimeContext sofaRuntimeContext,
-                                                                                 SofaRuntimeProperties sofaRuntimeProperties,
-                                                                                 BindingAdapterFactory bindingAdapterFactory,
+    public ServiceAnnotationBeanPostProcessor serviceAnnotationBeanPostProcessor(BindingAdapterFactory bindingAdapterFactory,
                                                                                  BindingConverterFactory bindingConverterFactory) {
-        return new ServiceAnnotationBeanPostProcessor(sofaRuntimeContext, sofaRuntimeProperties,
-            bindingAdapterFactory, bindingConverterFactory);
+        return new ServiceAnnotationBeanPostProcessor(bindingAdapterFactory,
+            bindingConverterFactory);
     }
 
     @Bean

--- a/runtime-sofa-boot-starter/src/test/java/com/alipay/sofa/runtime/spring/config/SofaRuntimePropertiesTest.java
+++ b/runtime-sofa-boot-starter/src/test/java/com/alipay/sofa/runtime/spring/config/SofaRuntimePropertiesTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.runtime.spring.config;
+
+import com.alipay.sofa.runtime.spring.configuration.SofaRuntimeAutoConfiguration;
+import org.junit.After;
+import org.junit.Test;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.util.EnvironmentTestUtils;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import static org.junit.Assert.assertTrue;
+
+public class SofaRuntimePropertiesTest {
+
+    private final AnnotationConfigApplicationContext applicationContext = new AnnotationConfigApplicationContext();
+
+    @After
+    public void closeContext() {
+        this.applicationContext.close();
+    }
+
+    @Test
+    public void testProperties() {
+        EnvironmentTestUtils.addEnvironment(this.applicationContext,
+            "com.alipay.sofa.boot.disableJvmFirst=true");
+        this.applicationContext.register(SofaRuntimeAutoConfiguration.class,
+            EnableConfigurationPropertiesConfiguration.class);
+        this.applicationContext.refresh();
+        SofaRuntimeProperties properties = applicationContext.getBean(SofaRuntimeProperties.class);
+        assertTrue(properties.isDisableJvmFirst());
+    }
+
+    // It is recommended to use @EnableConfigurationProperties(SofaRuntimeProperties.class) in the SofaRuntimeAutoConfiguration,
+    // but the bean name change will break the current tests
+    @EnableConfigurationProperties
+    static class EnableConfigurationPropertiesConfiguration {
+    }
+}


### PR DESCRIPTION
fix #87 .