### PR TITLE
ignore git ~/.m2 for mac sourceTree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ tmp/
 velocity.log
 .DS_Store
 logs
+.m2


### PR DESCRIPTION
增加mac soucetree下忽略~/.m2文件夹