### PR TITLE
Update maven-javadoc-plugin version to 2.10.1.(#133)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9.1</version>
+                <version>2.10.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>


### PR DESCRIPTION
升级 maven-javadoc-plugin 插件版本由之前的 2.9.1 到 2.10.1，以修复在 Mac OSX 下可能出现如下报错：
> Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:2.9.1:jar (attach-javadocs) on project infra-sofa-boot-starter: MavenReportException: Error while creating archive: Unable to find javadoc command: The environment variable JAVA_HOME is not correctly set. -> [Help 1]