### PR TITLE
SOFABoot add configuration com.alipay.sofa.healthcheck.enabled to disable readiness check

### DIFF
--- a/healthcheck-sofa-boot-starter/src/main/java/com/alipay/sofa/healthcheck/service/EndPointConfig.java
+++ b/healthcheck-sofa-boot-starter/src/main/java/com/alipay/sofa/healthcheck/service/EndPointConfig.java
@@ -16,8 +16,8 @@
  */
 package com.alipay.sofa.healthcheck.service;
 
-import org.springframework.boot.actuate.condition.ConditionalOnEnabledEndpoint;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -36,7 +36,7 @@ public class EndPointConfig {
 
     @Bean
     @ConditionalOnBean(SofaBootReadinessCheckEndpoint.class)
-    @ConditionalOnEnabledEndpoint(READINESS_CHECK_ENDPOINT_NAME)
+    @ConditionalOnProperty(prefix = "com.alipay.sofa.healthcheck", name = "enabled", matchIfMissing = true)
     public SofaBootReadinessCheckMvcEndpoint sofaBootReadinessCheckMvcEndpoint(SofaBootReadinessCheckEndpoint delegate) {
         return new SofaBootReadinessCheckMvcEndpoint(delegate);
     }

--- a/healthcheck-sofa-boot-starter/src/main/java/com/alipay/sofa/healthcheck/service/SofaBootReadinessCheckEndpoint.java
+++ b/healthcheck-sofa-boot-starter/src/main/java/com/alipay/sofa/healthcheck/service/SofaBootReadinessCheckEndpoint.java
@@ -23,6 +23,7 @@ import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.Health.Builder;
 import org.springframework.boot.actuate.health.HealthAggregator;
 import org.springframework.boot.actuate.health.OrderedHealthAggregator;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.util.CollectionUtils;
 
 import java.util.HashMap;
@@ -35,7 +36,7 @@ import java.util.Map;
  * @author liangen
  * @version $Id: StartUpHealthCheckStatusCheckInfo.java, v 0.1 2018年02月02日 下午11:34 liangen Exp $
  */
-
+@ConfigurationProperties(prefix = "com.alipay.sofa.healthcheck")
 public class SofaBootReadinessCheckEndpoint extends AbstractEndpoint<Health> {
 
     private final HealthAggregator healthAggregator = new OrderedHealthAggregator();

--- a/healthcheck-sofa-boot-starter/src/test/java/com/alipay/sofa/healthcheck/base/AbstractTestBase.java
+++ b/healthcheck-sofa-boot-starter/src/test/java/com/alipay/sofa/healthcheck/base/AbstractTestBase.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.healthcheck.base;
+
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.embedded.LocalServerPort;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * AbstractTestBase
+ *
+ * @author yangguanchao
+ * @since 2018/07/28
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(classes = SpringBootWebApplication.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public abstract class AbstractTestBase {
+
+    /**
+     * 8080
+     */
+    @LocalServerPort
+    protected int              definedPort;
+
+    @Autowired
+    protected TestRestTemplate testRestTemplate;
+
+    public String getUrlPath(String path) {
+        return "http://localhost:" + definedPort + path;
+    }
+}

--- a/healthcheck-sofa-boot-starter/src/test/java/com/alipay/sofa/healthcheck/base/SpringBootWebApplication.java
+++ b/healthcheck-sofa-boot-starter/src/test/java/com/alipay/sofa/healthcheck/base/SpringBootWebApplication.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.healthcheck.base;
+
+import org.springframework.boot.SpringApplication;
+
+/**
+ * SpringBootWebApplication
+ *
+ * @author yangguanchao
+ * @since 2018/07/28
+ */
+@org.springframework.boot.autoconfigure.SpringBootApplication
+public class SpringBootWebApplication {
+
+    public static void main(String[] args) throws Exception {
+        SpringApplication springApplication = new SpringApplication(SpringBootWebApplication.class);
+        springApplication.run(args);
+    }
+}

--- a/healthcheck-sofa-boot-starter/src/test/java/com/alipay/sofa/healthcheck/enable/SofaBootReadinessCheckEnableTest.java
+++ b/healthcheck-sofa-boot-starter/src/test/java/com/alipay/sofa/healthcheck/enable/SofaBootReadinessCheckEnableTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.healthcheck.enable;
+
+import com.alipay.sofa.healthcheck.base.AbstractTestBase;
+import org.junit.Test;
+import org.springframework.boot.actuate.health.Status;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * SofaBootReadinessCheckEnableTest
+ *
+ * @author yangguanchao
+ * @since 2018/07/28
+ */
+public class SofaBootReadinessCheckEnableTest extends AbstractTestBase {
+
+    @Test
+    public void testEnableReadinessCheck() throws Exception {
+        String urlHttp = this.getUrlPath("/health/readiness");
+        ResponseEntity<Map> response = this.testRestTemplate.getForEntity(urlHttp, Map.class);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(Status.UP.getCode(), response.getBody().get("status").toString());
+    }
+}

--- a/healthcheck-sofa-boot-starter/src/test/java/com/alipay/sofa/healthcheck/enable/SofaBootReadinessCheckUnableTest.java
+++ b/healthcheck-sofa-boot-starter/src/test/java/com/alipay/sofa/healthcheck/enable/SofaBootReadinessCheckUnableTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.healthcheck.enable;
+
+import com.alipay.sofa.healthcheck.base.AbstractTestBase;
+import org.junit.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * SofaBootReadinessCheckEnableTest
+ *
+ * @author yangguanchao
+ * @since 2018/07/28
+ */
+@ActiveProfiles("disable")
+public class SofaBootReadinessCheckUnableTest extends AbstractTestBase {
+
+    @Test
+    public void testUnableReadinessCheck() throws Exception {
+        String urlHttp = this.getUrlPath("/health/readiness");
+        ResponseEntity<Map> response = this.testRestTemplate.getForEntity(urlHttp, Map.class);
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+    }
+}

--- a/healthcheck-sofa-boot-starter/src/test/resources/application-disable.properties
+++ b/healthcheck-sofa-boot-starter/src/test/resources/application-disable.properties
@@ -1,0 +1,1 @@
+com.alipay.sofa.healthcheck.enabled = false

--- a/healthcheck-sofa-boot-starter/src/test/resources/application.properties
+++ b/healthcheck-sofa-boot-starter/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+com.alipay.sofa.healthcheck.enabled = true


### PR DESCRIPTION
## Motivation:

SOFABoot add configuration `com.alipay.sofa.healthcheck.enabled` to disable readiness check

## Modification:

Add  `com.alipay.sofa.healthcheck.enabled` configuration for disable readiness check.

## Result:
Fixes #153 

