### PR TITLE
Check whether it is neccessary when copy BeanPostProcessors and BeanFactoryPostProcessors from Root Application Context to SOFA Module

### DIFF
--- a/isle-sofa-boot-starter/src/main/java/com/alipay/sofa/isle/loader/DynamicSpringContextLoader.java
+++ b/isle-sofa-boot-starter/src/main/java/com/alipay/sofa/isle/loader/DynamicSpringContextLoader.java
@@ -145,7 +145,9 @@ public class DynamicSpringContextLoader implements SpringContextLoader {
         Map<String, BeanDefinition> processors = (Map<String, BeanDefinition>) rootApplicationContext
             .getBean(SofaModuleFrameworkConstants.PROCESSORS_OF_ROOT_APPLICATION_CONTEXT);
         for (Map.Entry<String, BeanDefinition> entry : processors.entrySet()) {
-            beanFactory.registerBeanDefinition(entry.getKey(), entry.getValue());
+            if (!beanFactory.containsBeanDefinition(entry.getKey())) {
+                beanFactory.registerBeanDefinition(entry.getKey(), entry.getValue());
+            }
         }
     }
 }

--- a/isle-sofa-boot-starter/src/test/java/com/alipay/sofa/isle/integration/IntegrationTest.java
+++ b/isle-sofa-boot-starter/src/test/java/com/alipay/sofa/isle/integration/IntegrationTest.java
@@ -19,8 +19,10 @@ package com.alipay.sofa.isle.integration;
 import com.alipay.sofa.healthcheck.core.HealthChecker;
 import com.alipay.sofa.isle.ApplicationRuntimeModel;
 import com.alipay.sofa.isle.constants.SofaModuleFrameworkConstants;
+import com.alipay.sofa.isle.scan.SampleService;
 import com.alipay.sofa.isle.spring.config.SofaModuleProperties;
 import com.alipay.sofa.isle.util.ClassPathUtil;
+import com.alipay.sofa.runtime.api.annotation.SofaReference;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -49,6 +51,9 @@ public class IntegrationTest implements ApplicationContextAware {
     @Autowired
     private SofaModuleProperties sofaModuleProperties;
 
+    @SofaReference(uniqueId = "componentScanTest")
+    private SampleService        sampleService;
+
     @BeforeClass
     public static void before() throws Exception {
         // test JarDeploymentDescriptor, add jar file at runtime
@@ -65,7 +70,7 @@ public class IntegrationTest implements ApplicationContextAware {
         assertEquals(sofaModuleProperties.getActiveProfiles(), "dev");
         assertEquals(sofaModuleProperties.isModuleStartUpParallel(), true);
         assertEquals(sofaModuleProperties.isPublishEventToParent(), false);
-        assertEquals(sofaModuleProperties.isAllowBeanDefinitionOverriding(), true);
+        assertEquals(sofaModuleProperties.isAllowBeanDefinitionOverriding(), false);
         assertEquals(sofaModuleProperties.getBeanLoadCost(), 0);
 
         ApplicationRuntimeModel applicationRuntimeModel = (ApplicationRuntimeModel) applicationContext
@@ -97,6 +102,12 @@ public class IntegrationTest implements ApplicationContextAware {
         Assert.assertEquals(0, healthChecker.getRetryCount());
         Assert.assertEquals(0, healthChecker.getRetryTimeInterval());
         Assert.assertEquals(true, healthChecker.isStrictCheck());
+    }
+
+    @Test
+    public void testComponentScan() {
+        Assert.assertNotNull(sampleService);
+        "Hello from com.alipay.sofa.isle.scan.SampleServiceImpl.".equals(sampleService.message());
     }
 
     @Override

--- a/isle-sofa-boot-starter/src/test/java/com/alipay/sofa/isle/integration/SofaBootTestApplication.java
+++ b/isle-sofa-boot-starter/src/test/java/com/alipay/sofa/isle/integration/SofaBootTestApplication.java
@@ -28,5 +28,4 @@ public class SofaBootTestApplication {
         SpringApplication springApplication = new SpringApplication(SofaBootTestApplication.class);
         springApplication.run(args);
     }
-
 }

--- a/isle-sofa-boot-starter/src/test/java/com/alipay/sofa/isle/integration/SofaBootTestAutoConfiguration.java
+++ b/isle-sofa-boot-starter/src/test/java/com/alipay/sofa/isle/integration/SofaBootTestAutoConfiguration.java
@@ -21,7 +21,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
- * @author xuanbei 18/8/1
+ * @author xuanbei
+ * @since 2.4.4
  */
 @Configuration
 public class SofaBootTestAutoConfiguration {

--- a/isle-sofa-boot-starter/src/test/java/com/alipay/sofa/isle/integration/SofaBootTestAutoConfiguration.java
+++ b/isle-sofa-boot-starter/src/test/java/com/alipay/sofa/isle/integration/SofaBootTestAutoConfiguration.java
@@ -25,7 +25,6 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration
 public class SofaBootTestAutoConfiguration {
-
     /**
      * define SampleBeanPostProcessor in Root Application Context.
      *

--- a/isle-sofa-boot-starter/src/test/java/com/alipay/sofa/isle/integration/SofaBootTestAutoConfiguration.java
+++ b/isle-sofa-boot-starter/src/test/java/com/alipay/sofa/isle/integration/SofaBootTestAutoConfiguration.java
@@ -16,17 +16,23 @@
  */
 package com.alipay.sofa.isle.integration;
 
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
+import com.alipay.sofa.isle.processor.SampleBeanPostProcessor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 /**
- * @author xuanbei 18/5/8
+ * @author xuanbei 18/8/1
  */
-@SpringBootApplication
-public class SofaBootTestApplication {
-    public static void main(String[] args) {
-        SpringApplication springApplication = new SpringApplication(SofaBootTestApplication.class);
-        springApplication.run(args);
-    }
+@Configuration
+public class SofaBootTestAutoConfiguration {
 
+    /**
+     * define SampleBeanPostProcessor in Root Application Context.
+     *
+     * @return SampleBeanPostProcessor
+     */
+    @Bean
+    public SampleBeanPostProcessor sampleBeanPostProcessor() {
+        return new SampleBeanPostProcessor();
+    }
 }

--- a/isle-sofa-boot-starter/src/test/java/com/alipay/sofa/isle/processor/SampleBeanPostProcessor.java
+++ b/isle-sofa-boot-starter/src/test/java/com/alipay/sofa/isle/processor/SampleBeanPostProcessor.java
@@ -20,7 +20,8 @@ import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 
 /**
- * @author xuanbei 18/8/1
+ * @author xuanbei
+ * @since 2.4.4
  */
 public class SampleBeanPostProcessor implements BeanPostProcessor {
     @Override

--- a/isle-sofa-boot-starter/src/test/java/com/alipay/sofa/isle/processor/SampleBeanPostProcessor.java
+++ b/isle-sofa-boot-starter/src/test/java/com/alipay/sofa/isle/processor/SampleBeanPostProcessor.java
@@ -14,19 +14,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.alipay.sofa.isle.integration;
+package com.alipay.sofa.isle.processor;
 
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
 
 /**
- * @author xuanbei 18/5/8
+ * @author xuanbei 18/8/1
  */
-@SpringBootApplication
-public class SofaBootTestApplication {
-    public static void main(String[] args) {
-        SpringApplication springApplication = new SpringApplication(SofaBootTestApplication.class);
-        springApplication.run(args);
+public class SampleBeanPostProcessor implements BeanPostProcessor {
+    @Override
+    public Object postProcessBeforeInitialization(Object bean, String beanName)
+                                                                               throws BeansException {
+        return bean;
     }
 
+    @Override
+    public Object postProcessAfterInitialization(Object bean, String beanName)
+                                                                              throws BeansException {
+        return bean;
+    }
 }

--- a/isle-sofa-boot-starter/src/test/java/com/alipay/sofa/isle/scan/SampleService.java
+++ b/isle-sofa-boot-starter/src/test/java/com/alipay/sofa/isle/scan/SampleService.java
@@ -14,19 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.alipay.sofa.isle.integration;
-
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
+package com.alipay.sofa.isle.scan;
 
 /**
- * @author xuanbei 18/5/8
+ * @author xuanbei 18/8/1
  */
-@SpringBootApplication
-public class SofaBootTestApplication {
-    public static void main(String[] args) {
-        SpringApplication springApplication = new SpringApplication(SofaBootTestApplication.class);
-        springApplication.run(args);
-    }
-
+public interface SampleService {
+    String message();
 }

--- a/isle-sofa-boot-starter/src/test/java/com/alipay/sofa/isle/scan/SampleService.java
+++ b/isle-sofa-boot-starter/src/test/java/com/alipay/sofa/isle/scan/SampleService.java
@@ -17,7 +17,8 @@
 package com.alipay.sofa.isle.scan;
 
 /**
- * @author xuanbei 18/8/1
+ * @author xuanbei
+ * @since 2.4.4
  */
 public interface SampleService {
     String message();

--- a/isle-sofa-boot-starter/src/test/java/com/alipay/sofa/isle/scan/SampleServiceImpl.java
+++ b/isle-sofa-boot-starter/src/test/java/com/alipay/sofa/isle/scan/SampleServiceImpl.java
@@ -14,19 +14,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.alipay.sofa.isle.integration;
+package com.alipay.sofa.isle.scan;
 
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
+import com.alipay.sofa.runtime.api.annotation.SofaService;
+import org.springframework.stereotype.Component;
 
 /**
- * @author xuanbei 18/5/8
+ * @author xuanbei 18/8/1
  */
-@SpringBootApplication
-public class SofaBootTestApplication {
-    public static void main(String[] args) {
-        SpringApplication springApplication = new SpringApplication(SofaBootTestApplication.class);
-        springApplication.run(args);
+@Component
+@SofaService(uniqueId = "componentScanTest")
+public class SampleServiceImpl implements SampleService {
+    @Override
+    public String message() {
+        return "Hello from com.alipay.sofa.isle.scan.SampleServiceImpl.";
     }
-
 }

--- a/isle-sofa-boot-starter/src/test/java/com/alipay/sofa/isle/scan/SampleServiceImpl.java
+++ b/isle-sofa-boot-starter/src/test/java/com/alipay/sofa/isle/scan/SampleServiceImpl.java
@@ -20,7 +20,8 @@ import com.alipay.sofa.runtime.api.annotation.SofaService;
 import org.springframework.stereotype.Component;
 
 /**
- * @author xuanbei 18/8/1
+ * @author xuanbei
+ * @since 2.4.4
  */
 @Component
 @SofaService(uniqueId = "componentScanTest")

--- a/isle-sofa-boot-starter/src/test/resources/META-INF/spring/test-service.xml
+++ b/isle-sofa-boot-starter/src/test/resources/META-INF/spring/test-service.xml
@@ -2,7 +2,13 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-            http://www.springframework.org/schema/beans/spring-beans.xsd"
+            http://www.springframework.org/schema/beans/spring-beans.xsd
+            http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd"
        default-autowire="byName">
+    <context:component-scan base-package="com.alipay.sofa.isle.scan" />
+
+    <!-- define SampleBeanPostProcessor in SOFABoot Module Application Context. -->
+    <bean id="sampleBeanPostProcessor" class="com.alipay.sofa.isle.processor.SampleBeanPostProcessor" />
 </beans>

--- a/isle-sofa-boot-starter/src/test/resources/config/application.properties
+++ b/isle-sofa-boot-starter/src/test/resources/config/application.properties
@@ -2,5 +2,5 @@ spring.application.name=isle-test
 
 com.alipay.sofa.boot.active-profiles=dev
 com.alipay.sofa.boot.bean-load-cost=0
-com.alipay.sofa.boot.allow-bean-definition-overriding=true
+com.alipay.sofa.boot.allow-bean-definition-overriding=false
 com.alipay.sofa.boot.module-start-up-parallel=false


### PR DESCRIPTION
Check whether it is neccessary when copy BeanPostProcessors and BeanFactoryPostProcessors from Root Application Context to SOFA Module.