### PR TITLE
 Provide friendly notice when the property of spring.application.name is missing.

### DIFF
--- a/infra-sofa-boot-starter/src/main/java/com/alipay/sofa/infra/autoconfigure/SofaBootInfraAutoConfiguration.java
+++ b/infra-sofa-boot-starter/src/main/java/com/alipay/sofa/infra/autoconfigure/SofaBootInfraAutoConfiguration.java
@@ -43,6 +43,7 @@ public class SofaBootInfraAutoConfiguration {
 
     @Configuration
     @ConditionalOnWebApplication
+    @ConditionalOnClass(Endpoint.class)
     public static class SofaBootVersionEndpointMvcAdapterConfiguration {
         @Bean
         @ConditionalOnProperty(prefix = "com.alipay.sofa.versions", name = "enabled", matchIfMissing = true)

--- a/infra-sofa-boot-starter/src/main/java/com/alipay/sofa/infra/env/EnvironmentCustomizer.java
+++ b/infra-sofa-boot-starter/src/main/java/com/alipay/sofa/infra/env/EnvironmentCustomizer.java
@@ -36,6 +36,10 @@ public class EnvironmentCustomizer implements EnvironmentPostProcessor {
         PropertySource propertySource = new PropertiesPropertySource("version",
             getSofaBootVersionProperties());
         environment.getPropertySources().addLast(propertySource);
+        /**
+         * set required properties, {@link MissingRequiredPropertiesException}
+         **/
+        environment.setRequiredProperties(CommonMiddlewareConstants.APP_NAME_KEY);
     }
 
     /**

--- a/isle-sofa-boot-starter/src/main/java/com/alipay/sofa/isle/constants/SofaModuleFrameworkConstants.java
+++ b/isle-sofa-boot-starter/src/main/java/com/alipay/sofa/isle/constants/SofaModuleFrameworkConstants.java
@@ -26,7 +26,6 @@ public interface SofaModuleFrameworkConstants {
     String APPLICATION                            = "SOFABOOT-APPLICATION";
     String PROCESSORS_OF_ROOT_APPLICATION_CONTEXT = "PROCESSORS_OF_ROOT_APPLICATION_CONTEXT";
     String SOFA_MODULE_FILE                       = "sofa-module.properties";
-    String APPLICATION_NAME                       = "spring.application.name";
     String SPRING_CONTEXT_PATH                    = "META-INF/spring";
     String PROFILE_SEPARATOR                      = ",";
     String DEFAULT_PROFILE_VALUE                  = "default";

--- a/isle-sofa-boot-starter/src/main/java/com/alipay/sofa/isle/stage/AbstractPipelineStage.java
+++ b/isle-sofa-boot-starter/src/main/java/com/alipay/sofa/isle/stage/AbstractPipelineStage.java
@@ -16,7 +16,7 @@
  */
 package com.alipay.sofa.isle.stage;
 
-import com.alipay.sofa.isle.constants.SofaModuleFrameworkConstants;
+import com.alipay.sofa.infra.constants.CommonMiddlewareConstants;
 import com.alipay.sofa.runtime.spi.log.SofaLogger;
 import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.core.Ordered;
@@ -35,7 +35,7 @@ public abstract class AbstractPipelineStage implements PipelineStage, Ordered {
     public AbstractPipelineStage(AbstractApplicationContext applicationContext) {
         this.applicationContext = applicationContext;
         appName = applicationContext.getEnvironment().getProperty(
-            SofaModuleFrameworkConstants.APPLICATION_NAME);
+            CommonMiddlewareConstants.APP_NAME_KEY);
     }
 
     @Override

--- a/isle-sofa-boot-starter/src/test/java/com/alipay/sofa/isle/DeploymentExceptionTest.java
+++ b/isle-sofa-boot-starter/src/test/java/com/alipay/sofa/isle/DeploymentExceptionTest.java
@@ -16,6 +16,7 @@
  */
 package com.alipay.sofa.isle;
 
+import com.alipay.sofa.infra.constants.CommonMiddlewareConstants;
 import com.alipay.sofa.isle.constants.SofaModuleFrameworkConstants;
 import com.alipay.sofa.isle.deployment.DeploymentBuilder;
 import com.alipay.sofa.isle.deployment.DeploymentDescriptorConfiguration;
@@ -63,8 +64,8 @@ public class DeploymentExceptionTest {
 
         ConfigurableEnvironment environment = mock(ConfigurableEnvironment.class);
         when(applicationContext.getEnvironment()).thenReturn(environment);
-        when(environment.getProperty(SofaModuleFrameworkConstants.APPLICATION_NAME)).thenReturn(
-            "testCase");
+        when(environment.getProperty(CommonMiddlewareConstants.APP_NAME_KEY))
+            .thenReturn("testCase");
 
         new SpringContextInstallStage(applicationContext).process();
     }


### PR DESCRIPTION
fix #217 