### PR TITLE
Fix logger linkage error.

### DIFF
--- a/infra-sofa-boot-starter/src/main/java/com/alipay/sofa/infra/env/EnvironmentCustomizer.java
+++ b/infra-sofa-boot-starter/src/main/java/com/alipay/sofa/infra/env/EnvironmentCustomizer.java
@@ -20,7 +20,6 @@ import com.alipay.sofa.infra.autoconfigure.SofaBootInfraAutoConfiguration;
 import com.alipay.sofa.infra.constants.SofaBootInfraConstants;
 import com.alipay.sofa.infra.utils.SOFABootEnvUtils;
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.context.config.ConfigFileApplicationListener;
 import org.springframework.boot.env.EnvironmentPostProcessor;
 import org.springframework.core.env.*;
 import org.springframework.util.StringUtils;

--- a/runtime-sofa-boot-starter/src/main/java/com/alipay/sofa/runtime/spring/initializer/SofaRuntimeSpringContextInitializer.java
+++ b/runtime-sofa-boot-starter/src/main/java/com/alipay/sofa/runtime/spring/initializer/SofaRuntimeSpringContextInitializer.java
@@ -19,6 +19,7 @@ package com.alipay.sofa.runtime.spring.initializer;
 import com.alipay.sofa.common.log.Constants;
 import com.alipay.sofa.infra.log.space.SofaBootLogSpaceIsolationInit;
 import com.alipay.sofa.infra.utils.SOFABootEnvUtils;
+import com.alipay.sofa.runtime.spi.log.SofaLogger;
 import com.alipay.sofa.runtime.spi.log.SofaRuntimeLoggerFactory;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -41,7 +42,6 @@ public class SofaRuntimeSpringContextInitializer
                                     + SofaRuntimeLoggerFactory.SOFA_RUNTIME_LOG_SPACE;
         SofaBootLogSpaceIsolationInit.initSofaBootLogger(environment, runtimeLogLevelKey);
 
-        SofaRuntimeLoggerFactory.getLogger(SofaRuntimeSpringContextInitializer.class).info(
-            "SOFABoot Runtime Starting!");
+        SofaLogger.info("SOFABoot Runtime Starting!");
     }
 }


### PR DESCRIPTION
SofaLogger is recommended way to log message in SOFABoot. It may leads linkage error when use SofaRuntimeLoggerFactory in ark container.