### PR TITLE
add missing apiType logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ velocity.log
 .DS_Store
 logs
 .m2
+.java-version
+

--- a/runtime-sofa-boot-starter/src/main/java/com/alipay/sofa/runtime/spring/factory/AbstractContractFactoryBean.java
+++ b/runtime-sofa-boot-starter/src/main/java/com/alipay/sofa/runtime/spring/factory/AbstractContractFactoryBean.java
@@ -95,7 +95,9 @@ public abstract class AbstractContractFactoryBean implements InitializingBean, F
             SofaRuntimeFrameworkConstants.SOFA_RUNTIME_CONTEXT_BEAN_ID, SofaRuntimeContext.class);
         bindingConverterFactory = getBindingConverterFactory();
         bindingAdapterFactory = getBindingAdapterFactory();
-        this.bindings = parseBindings(tempElements, applicationContext, isInBinding());
+        if (!apiType) {
+            this.bindings = parseBindings(tempElements, applicationContext, isInBinding());
+        }
         doAfterPropertiesSet();
     }
 

--- a/runtime-sofa-boot-starter/src/test/java/com/alipay/sofa/runtime/integration/IntegrationTest.java
+++ b/runtime-sofa-boot-starter/src/test/java/com/alipay/sofa/runtime/integration/IntegrationTest.java
@@ -131,7 +131,7 @@ public class IntegrationTest extends AbstractTestBase {
             .getBean("&"
                      + SofaBeanNameGenerator.generateSofaReferenceBeanName(SampleService.class,
                          "methodBeanClassAnnotationSampleService"));
-        Assert.assertTrue(serviceFactoryBean.isApiType());
+        Assert.assertTrue(referenceFactoryBean.isApiType());
 
         /**
          * {@link com.alipay.sofa.runtime.integration.base.AbstractTestBase.IntegrationTestConfiguration.BeforeConfiguration}

--- a/runtime-sofa-boot-starter/src/test/java/com/alipay/sofa/runtime/integration/TestSofaServiceAndReferenceException.java
+++ b/runtime-sofa-boot-starter/src/test/java/com/alipay/sofa/runtime/integration/TestSofaServiceAndReferenceException.java
@@ -23,6 +23,9 @@ import java.util.Map;
 
 import com.alipay.sofa.runtime.api.annotation.SofaReference;
 import com.alipay.sofa.runtime.api.annotation.SofaReferenceBinding;
+import com.alipay.sofa.runtime.api.annotation.SofaServiceBinding;
+import com.alipay.sofa.runtime.api.binding.BindingType;
+import com.alipay.sofa.runtime.spring.factory.ServiceFactoryBean;
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -87,6 +90,29 @@ public class TestSofaServiceAndReferenceException extends TestBase {
         properties.put("spring.application.name", "runtime-test");
         properties.put("multiSofaReference", "true");
         initApplicationContext(properties, EmptyConfiguration.class);
+    }
+
+    @Test
+    public void testSofaServiceWithMultipleBindings() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("spring.application.name", "runtime-test");
+        initApplicationContext(properties, MultipleBindingsSofaServiceConfiguration.class);
+        ServiceFactoryBean bean = applicationContext.getBean(ServiceFactoryBean.class);
+        Assert.assertEquals(2, bean.getBindings().size());
+        Assert.assertEquals(new BindingType("jvm"), bean.getBindings().get(0).getBindingType());
+        Assert.assertEquals(new BindingType("jvm"), bean.getBindings().get(1).getBindingType());
+    }
+
+    @Configuration
+    @EnableAutoConfiguration
+    static class MultipleBindingsSofaServiceConfiguration {
+
+        // 测试使用注解配置多个 binding，因为 sofa-boot 没有 binding converter，所以只能使用多个 jvm binding
+        @Bean
+        @SofaService(bindings = { @SofaServiceBinding, @SofaServiceBinding })
+        SampleService sampleService() {
+            return new SampleServiceImpl("test");
+        }
     }
 
     @EnableAutoConfiguration

--- a/runtime-sofa-boot-starter/src/test/java/com/alipay/sofa/runtime/integration/TestSofaServiceAndReferenceException.java
+++ b/runtime-sofa-boot-starter/src/test/java/com/alipay/sofa/runtime/integration/TestSofaServiceAndReferenceException.java
@@ -107,7 +107,7 @@ public class TestSofaServiceAndReferenceException extends TestBase {
     @EnableAutoConfiguration
     static class MultipleBindingsSofaServiceConfiguration {
 
-        // 测试使用注解配置多个 binding，因为 sofa-boot 没有 binding converter，所以只能使用多个 jvm binding
+        // since the sofa-boot does not have any binding converter implementation, we can use two jvm bindings for now.
         @Bean
         @SofaService(bindings = { @SofaServiceBinding, @SofaServiceBinding })
         SampleService sampleService() {


### PR DESCRIPTION
It seems that 2.x lost this part of the logic, causing the provider created with `@SofaService` lost the bindings.

--------

WIP:

- [x] add some tests for this case